### PR TITLE
Switch to content offset approach

### DIFF
--- a/ASCollectionView/Source/ASCollectionView.swift
+++ b/ASCollectionView/Source/ASCollectionView.swift
@@ -109,8 +109,7 @@ public class ASCollectionView: UICollectionView, UICollectionViewDataSource {
       * Custom data source
      */
     public var asDataSource: ASCollectionViewDataSource?
-    
-    private var displayLink: CADisplayLink!
+
     private var currentOrientation: UIInterfaceOrientation!
     
     // MARK: LifeCycle
@@ -118,13 +117,11 @@ public class ASCollectionView: UICollectionView, UICollectionViewDataSource {
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.setUp()
-        self.setUpParallax()
     }
     
     override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: layout)
         self.setUp()
-        self.setUpParallax()
     }
     
     private func setUp() {
@@ -136,17 +133,6 @@ public class ASCollectionView: UICollectionView, UICollectionViewDataSource {
         NotificationCenter.default.addObserver(self, selector: #selector(ASCollectionView.orientationChanged(_:)), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
         register(UICollectionReusableView.self, forSupplementaryViewOfKind: ASCollectionViewElement.MoreLoader, withReuseIdentifier: kMoreLoaderIdentifier)
         addObserver(self, forKeyPath: kContentOffset, options: NSKeyValueObservingOptions.new, context: nil)
-    }
-    
-    private func setUpParallax() {
-        weak var weakSelf = self
-        displayLink = CADisplayLink(target: weakSelf!, selector: #selector(ASCollectionView.doParallax(_:)))
-        if #available(iOS 10.0, *) {
-            displayLink.preferredFramesPerSecond = 1
-        } else {
-            displayLink.frameInterval = 1
-        }
-        displayLink.add(to: RunLoop.current, forMode: RunLoopMode.commonModes)
     }
     
     // MARK: Key-Value Observer
@@ -235,7 +221,7 @@ public class ASCollectionView: UICollectionView, UICollectionViewDataSource {
     
     // MARK: Parallax Effects
     
-    func doParallax(_ displayLink: CADisplayLink) {
+    func doParallax() {
         let visibleCells = self.visibleCells
         for cell in visibleCells {
             if cell.isKind(of: ASCollectionViewParallaxCell.self) {
@@ -259,6 +245,14 @@ public class ASCollectionView: UICollectionView, UICollectionViewDataSource {
                 }
                 parallaxCell.setParallaxImageOffset(parallaxOffset)
             }
+        }
+    }
+
+    // MARK: Overridden Setters / Getters
+
+    override public var contentOffset: CGPoint {
+        didSet {
+            doParallax()
         }
     }
     
@@ -288,7 +282,6 @@ public class ASCollectionView: UICollectionView, UICollectionViewDataSource {
     // MARK: Deinit
     
     deinit {
-        displayLink.invalidate()
         NotificationCenter.default.removeObserver(self)
         removeObserver(self, forKeyPath: kContentOffset)
     }

--- a/ASCollectionViewTests/ASCollectionViewLayoutTests.swift
+++ b/ASCollectionViewTests/ASCollectionViewLayoutTests.swift
@@ -49,7 +49,7 @@ class ASCollectionViewLayoutTests: QuickSpec {
                     collectionViewLayout = MockCollectionViewLayout()
                 }
                 it("should return a valid attribute") {
-                    collectionViewLayout.layoutAttributesForElements(in: CGRect(x: 0, y: 0, width: 320, height: 50))
+                    _ = collectionViewLayout.layoutAttributesForElements(in: CGRect(x: 0, y: 0, width: 320, height: 50))
                     expect(collectionViewLayout.layoutAttributesForItem(at: IndexPath(row: 1, section: 0))).notTo(beNil())
                     expect(collectionViewLayout.layoutAttributesForItem(at: IndexPath(row: 1, section: 0))).notTo(equal(UICollectionViewLayoutAttributes(forCellWith: IndexPath(row: 0, section: 0))))
                 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.5)
+    activesupport (4.2.9)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (1.0.2)
+    clamp (0.6.5)
+    colored2 (3.1.2)
+    i18n (0.8.6)
+    mini_portile2 (2.1.0)
+    minitest (5.10.3)
+    nanaimo (0.2.3)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    rouge (2.0.7)
+    slather (2.4.2)
+      CFPropertyList (~> 2.2)
+      activesupport (>= 4.0.2, < 5)
+      clamp (~> 0.6)
+      nokogiri (~> 1.6)
+      xcodeproj (~> 1.4)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    xcodeproj (1.5.1)
+      CFPropertyList (~> 2.3.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.2.3)
+    xcpretty (0.2.8)
+      rouge (~> 2.0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (~> 1.6.8)
+  slather
+  xcpretty
+
+BUNDLED WITH
+   1.13.7


### PR DESCRIPTION
Gets rid of CADisplayLink usage which manually updates parallax cells' position for every 1 second. Would be great if we can measure performance for both approach as well just before merging. 